### PR TITLE
Fix: Ensure CustomMove data type safety

### DIFF
--- a/src/material/moves/MaterialMoveBuilder.ts
+++ b/src/material/moves/MaterialMoveBuilder.ts
@@ -48,7 +48,7 @@ export namespace MaterialMoveBuilder {
   /**
    * Creates a {@link CustomMove} object
    */
-  export const customMove = <Type extends number = number>(type: Type, data?: any): CustomMove => {
+  export const customMove = <Type extends number = number, Data = any>(type: Type, data?: Data): CustomMove => {
     const move: CustomMove = { kind: MoveKind.CustomMove, type }
     if (data !== undefined) move.data = data
     return move


### PR DESCRIPTION
This PR adds a type parameter on the `MoveBuilder.customMove` arrow function to help ensure custom move data type safety. The default type is `any` to ensure backwards compatibility