### PR TITLE
Fix: Improve `game.view` type safety

### DIFF
--- a/src/material/HiddenMaterialRules.ts
+++ b/src/material/HiddenMaterialRules.ts
@@ -29,11 +29,11 @@ import type { HidingSecretsStrategy, HidingStrategy } from './HidingStrategies'
  * If the game has secret information (some players have information not available to others, link cards in their hand), then you
  * must implement {@link SecretMaterialRules} instead.
  */
-export abstract class HiddenMaterialRules<P extends number = number, M extends number = number, L extends number = number, R extends number = number>
-  extends MaterialRules<P, M, L, R>
-  implements HiddenInformation<MaterialGame<P, M, L, R>, MaterialMove<P, M, L, R>, MaterialMove<P, M, L, R>> {
+export abstract class HiddenMaterialRules<P extends number = number, M extends number = number, L extends number = number, R extends number = number, V extends number = number>
+  extends MaterialRules<P, M, L, R, V>
+  implements HiddenInformation<MaterialGame<P, M, L, R, V>, MaterialMove<P, M, L, R, V>, MaterialMove<P, M, L, R, V>> {
 
-  constructor(game: MaterialGame<P, M, L, R>, private readonly client?: { player?: P }) {
+  constructor(game: MaterialGame<P, M, L, R, V>, private readonly client?: { player?: P }) {
     super(game)
   }
 
@@ -45,7 +45,7 @@ export abstract class HiddenMaterialRules<P extends number = number, M extends n
    */
   abstract readonly hidingStrategies: Partial<Record<M, Partial<Record<L, HidingStrategy<P, L>>>>>
 
-  randomize(move: MaterialMove<P, M, L, R>, player?: P): MaterialMove<P, M, L> & MaterialMoveRandomized<P, M, L, R> {
+  randomize(move: MaterialMove<P, M, L, R, V>, player?: P): MaterialMove<P, M, L, R, V> & MaterialMoveRandomized<P, M, L, R, V> {
     if (player !== undefined && this.isRevealingItemMove(move, player)) {
       // We need to know if a MoveItem has revealed something to the player to prevent the undo in that case.
       // To know that, we need the position of the item before the move.
@@ -57,7 +57,7 @@ export abstract class HiddenMaterialRules<P extends number = number, M extends n
     return super.randomize(move)
   }
 
-  private isRevealingItemMove(move: MaterialMove<P, M, L, R>, player: P): move is MoveItem<P, M, L> | MoveItemsAtOnce<P, M, L> {
+  private isRevealingItemMove(move: MaterialMove<P, M, L, R, V>, player: P): move is MoveItem<P, M, L> | MoveItemsAtOnce<P, M, L> {
     return (isMoveItem(move) && this.moveItemWillRevealSomething(move, player))
       || (isMoveItemsAtOnce(move) && this.moveAtOnceWillRevealSomething(move, player))
   }
@@ -72,7 +72,7 @@ export abstract class HiddenMaterialRules<P extends number = number, M extends n
   /**
    * Moves that reveal some information (like drawing a card) cannot be predicted by the player.
    */
-  isUnpredictableMove(move: MaterialMove<P, M, L, R>, player: P): boolean {
+  isUnpredictableMove(move: MaterialMove<P, M, L, R, V>, player: P): boolean {
     if (isMoveItem(move)) {
       return this.moveItemWillRevealSomething(move, player)
     } else if (isMoveItemsAtOnce(move)) {
@@ -91,7 +91,7 @@ export abstract class HiddenMaterialRules<P extends number = number, M extends n
   /**
    * Moves than reveals an information to someone cannot be undone by default
    */
-  protected moveBlocksUndo(move: MaterialMove<P, M, L, R>, player?: P): boolean {
+  protected moveBlocksUndo(move: MaterialMove<P, M, L, R, V>, player?: P): boolean {
     return super.moveBlocksUndo(move, player) || this.moveRevealedSomething(move)
   }
 
@@ -99,14 +99,14 @@ export abstract class HiddenMaterialRules<P extends number = number, M extends n
    * @param move A move to test
    * @returns true if the move revealed something to some player
    */
-  protected moveRevealedSomething(move: MaterialMove<P, M, L, R>): boolean {
+  protected moveRevealedSomething(move: MaterialMove<P, M, L, R, V>): boolean {
     return (isMoveItem(move) || isMoveItemsAtOnce(move)) && !!move.reveal
   }
 
   /**
    * With the material approach, we can offer a default working implementation for {@link HiddenInformation.getView}
    */
-  getView(player?: P): MaterialGame<P, M, L, R> {
+  getView(player?: P): MaterialGame<P, M, L, R, V> {
     return {
       ...this.game,
       items: mapValues(this.game.items, (items, itemsType) => {
@@ -150,7 +150,7 @@ export abstract class HiddenMaterialRules<P extends number = number, M extends n
    * To be able to know if a MoveItem cannot be undone, the server flags the moves with a "reveal" property.
    * This difference must be integrated without error during the callback.
    */
-  canIgnoreServerDifference(clientMove: MaterialMove<P, M, L, R>, serverMove: MaterialMove<P, M, L, R>): boolean {
+  canIgnoreServerDifference(clientMove: MaterialMove<P, M, L, R, V>, serverMove: MaterialMove<P, M, L, R, V>): boolean {
     if (isMoveItem(clientMove) && isMoveItem(serverMove)) {
       const { reveal, ...serverMoveWithoutReveal } = serverMove
       return isEqual(clientMove, serverMoveWithoutReveal)
@@ -161,7 +161,7 @@ export abstract class HiddenMaterialRules<P extends number = number, M extends n
   /**
    * With the material approach, we can offer a default working implementation for {@link HiddenInformation.getMoveView}
    */
-  getMoveView(move: MaterialMoveRandomized<P, M, L, R>, player?: P): MaterialMove<P, M, L, R> {
+  getMoveView(move: MaterialMoveRandomized<P, M, L, R, V>, player?: P): MaterialMove<P, M, L, R, V> {
     if (move.kind === MoveKind.ItemMove && move.itemType in this.hidingStrategies) {
       switch (move.type) {
         case ItemMoveType.Move:
@@ -254,7 +254,7 @@ export abstract class HiddenMaterialRules<P extends number = number, M extends n
   /**
    * Override of {@link MaterialRules.play} that also removes the hidden information from items, for example when a card is flipped face down
    */
-  play(move: MaterialMoveRandomized<P, M, L, R> | MaterialMoveView<P, M, L, R>, context?: PlayMoveContext): MaterialMove<P, M, L, R>[] {
+  play(move: MaterialMoveRandomized<P, M, L, R, V> | MaterialMoveView<P, M, L, R, V>, context?: PlayMoveContext): MaterialMove<P, M, L, R, V>[] {
     const result = super.play(move, context)
 
     if (this.client && isMoveItem(move) && this.hidingStrategies[move.itemType]) {

--- a/src/material/MaterialGameSetup.ts
+++ b/src/material/MaterialGameSetup.ts
@@ -10,24 +10,24 @@ import { TutorialState } from './tutorial'
 /**
  * Helper class to implement {@link GameSetup} when using the {@link MaterialRules} approach.
  */
-export abstract class MaterialGameSetup<P extends number = number, M extends number = number, L extends number = number, Options = any, R extends number = number>
-  implements GameSetup<MaterialGame<P, M, L, R>, Options> {
+export abstract class MaterialGameSetup<P extends number = number, M extends number = number, L extends number = number, Options = any, R extends number = number, V extends number = number>
+  implements GameSetup<MaterialGame<P, M, L, R, V>, Options> {
 
   /**
    * The rules of the game
    */
-  abstract Rules: MaterialRulesCreator<P, M, L, R>
+  abstract Rules: MaterialRulesCreator<P, M, L, R, V>
 
   /**
    * The game setup state we are working on
    * @protected
    */
-  protected game: MaterialGame<P, M, L, R> = { players: [], items: {}, memory: {} }
+  protected game: MaterialGame<P, M, L, R, V> = { players: [], items: {}, memory: {} }
 
   /**
    * Get an instance of the rules of the game
    */
-  get rules(): MaterialRules<P, M, L, R> {
+  get rules(): MaterialRules<P, M, L, R, V> {
     return new this.Rules(this.game)
   }
 
@@ -37,7 +37,7 @@ export abstract class MaterialGameSetup<P extends number = number, M extends num
    * @param tutorial Initial tutorial state if any
    * @returns the initial state of the game
    */
-  setup(options: Options, tutorial?: TutorialState<P, M, L, R>): MaterialGame<P, M, L, R> {
+  setup(options: Options, tutorial?: TutorialState<P, M, L, R>): MaterialGame<P, M, L, R, V> {
     this.game = { players: getPlayerIds(options), items: {}, memory: {}, tutorial }
     this.setupMaterial(options)
     this.start(options)
@@ -68,7 +68,7 @@ export abstract class MaterialGameSetup<P extends number = number, M extends num
    * @param move The MaterialMove to play
    * @protected
    */
-  protected playMove(move: MaterialMove<P, M, L, R>) {
+  protected playMove(move: MaterialMove<P, M, L, R, V>) {
     if (hasRandomMove(this.rules)) {
       move = this.rules.randomize(move)
     }

--- a/src/material/MaterialRules.ts
+++ b/src/material/MaterialRules.ts
@@ -46,13 +46,13 @@ import { isSimultaneousRule, MaterialRulesPart, MaterialRulesPartCreator } from 
  * @typeparam MaterialType - Numeric enum of the types of material manipulated in the game
  * @typeparam LocationType - Numeric enum of the types of location in the game where the material can be located
  */
-export abstract class MaterialRules<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number>
-  extends Rules<MaterialGame<Player, MaterialType, LocationType, RuleId>, MaterialMove<Player, MaterialType, LocationType, RuleId>, Player>
-  implements RandomMove<MaterialMove<Player, MaterialType, LocationType, RuleId>, MaterialMoveRandomized<Player, MaterialType, LocationType, RuleId>, Player>,
-    Undo<MaterialGame<Player, MaterialType, LocationType, RuleId>, MaterialMove<Player, MaterialType, LocationType, RuleId>, Player>,
-    UnpredictableMoves<MaterialMove<Player, MaterialType, LocationType, RuleId>>,
-    SequentialMoves<MaterialMove<Player, MaterialType, LocationType, RuleId>>,
-    TimeLimit<MaterialGame<Player, MaterialType, LocationType, RuleId>, MaterialMove<Player, MaterialType, LocationType, RuleId>, Player> {
+export abstract class MaterialRules<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number, View extends number = number>
+  extends Rules<MaterialGame<Player, MaterialType, LocationType, RuleId, View>, MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player>
+  implements RandomMove<MaterialMove<Player, MaterialType, LocationType, RuleId, View>, MaterialMoveRandomized<Player, MaterialType, LocationType, RuleId, View>, Player>,
+    Undo<MaterialGame<Player, MaterialType, LocationType, RuleId, View>, MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player>,
+    UnpredictableMoves<MaterialMove<Player, MaterialType, LocationType, RuleId, View>>,
+    SequentialMoves<MaterialMove<Player, MaterialType, LocationType, RuleId, View>>,
+    TimeLimit<MaterialGame<Player, MaterialType, LocationType, RuleId, View>, MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player> {
 
   /**
    * When you implement a game using the "material" approach, you are also strongly advised to split the rules of the game into many small parts.
@@ -60,7 +60,7 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
    * This "rules" property must be implemented to map each "rule id" with the corresponding MaterialRulesPart class.
    * This way, the behavior of the rules can be delegated to the corresponding rule part at each step of the game.
    */
-  abstract readonly rules: Record<RuleId, MaterialRulesPartCreator<Player, MaterialType, LocationType, RuleId>>
+  abstract readonly rules: Record<RuleId, MaterialRulesPartCreator<Player, MaterialType, LocationType, RuleId, View>>
 
   /**
    * The "location strategies" are global rules that always apply in a game when we want to maintain a consistency in the position of the material.
@@ -156,7 +156,7 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
    *
    * @returns the class that handled the rules of the game, at current specific game state.
    */
-  get rulesStep(): MaterialRulesPart<Player, MaterialType, LocationType, RuleId> | undefined {
+  get rulesStep(): MaterialRulesPart<Player, MaterialType, LocationType, RuleId, View> | undefined {
     if (!this.game.rule) return
     const RulesStep = this.rules[this.game.rule.id]
     if (!RulesStep) {
@@ -210,7 +210,7 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
   /**
    * In the material approach, the rules behavior is delegated to the current {@link rulesStep}. See {@link Rules.delegate}
    */
-  delegate(): Rules<MaterialGame<Player, MaterialType, LocationType, RuleId>, MaterialMove<Player, MaterialType, LocationType, RuleId>, Player> | undefined {
+  delegate(): Rules<MaterialGame<Player, MaterialType, LocationType, RuleId, View>, MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player> | undefined {
     return this.rulesStep
   }
 
@@ -220,8 +220,8 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
    * @returns the randomized move
    */
   randomize(
-    move: MaterialMove<Player, MaterialType, LocationType, RuleId>
-  ): MaterialMove<Player, MaterialType, LocationType, RuleId> & MaterialMoveRandomized<Player, MaterialType, LocationType, RuleId> {
+    move: MaterialMove<Player, MaterialType, LocationType, RuleId, View>
+  ): MaterialMove<Player, MaterialType, LocationType, RuleId, View> & MaterialMoveRandomized<Player, MaterialType, LocationType, RuleId, View> {
     if (isShuffle(move)) {
       return { ...move, newIndexes: shuffle(move.indexes) }
     } else if (isRoll(move)) {
@@ -250,10 +250,10 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
    * @returns Consequences of the move
    */
   play(
-    move: MaterialMoveRandomized<Player, MaterialType, LocationType, RuleId> | MaterialMoveView<Player, MaterialType, LocationType, RuleId>, context?: PlayMoveContext
-  ): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+    move: MaterialMoveRandomized<Player, MaterialType, LocationType, RuleId, View> | MaterialMoveView<Player, MaterialType, LocationType, RuleId, View>, context?: PlayMoveContext
+  ): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
 
-    const consequences: MaterialMove<Player, MaterialType, LocationType, RuleId>[] = []
+    const consequences: MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] = []
     switch (move.kind) {
       case MoveKind.ItemMove:
         consequences.push(...this.onPlayItemMove(move, context))
@@ -297,8 +297,8 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
   }
 
   protected onPlayItemMove(move: ItemMoveRandomized<Player, MaterialType, LocationType> | ItemMoveView<Player, MaterialType, LocationType>,
-                           context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
-    const consequences: MaterialMove<Player, MaterialType, LocationType, RuleId>[] = []
+                           context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
+    const consequences: MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] = []
     if (!context?.transient) {
       consequences.push(...this.beforeItemMove(move, context))
     }
@@ -331,20 +331,20 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
     return consequences
   }
 
-  protected beforeItemMove(move: ItemMove<Player, MaterialType, LocationType>, context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  protected beforeItemMove(move: ItemMove<Player, MaterialType, LocationType>, context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     return this.rulesStep?.beforeItemMove(move, context) ?? []
   }
 
-  protected afterItemMove(move: ItemMove<Player, MaterialType, LocationType>, context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  protected afterItemMove(move: ItemMove<Player, MaterialType, LocationType>, context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     return this.rulesStep?.afterItemMove(move, context) ?? []
   }
 
-  protected onCustomMove(move: CustomMove, context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  protected onCustomMove(move: CustomMove, context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     return this.rulesStep?.onCustomMove(move, context) ?? []
   }
 
-  private onPlayRulesMove(move: RuleMove<Player, RuleId>, context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
-    const consequences: MaterialMove<Player, MaterialType, LocationType, RuleId>[] = []
+  private onPlayRulesMove(move: RuleMove<Player, RuleId>, context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
+    const consequences: MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] = []
     const rulesStep = this.rulesStep
     if (move.type === RuleMoveType.EndPlayerTurn) {
       if (this.game.rule?.players?.includes(move.player)) {
@@ -364,7 +364,7 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
     return consequences
   }
 
-  private changeRule(move: RuleMove<Player, RuleId>, context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  private changeRule(move: RuleMove<Player, RuleId>, context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     const moves = this.rulesStep?.onRuleEnd(move, context) ?? []
     const rule = this.game.rule
     switch (move.type) {
@@ -408,8 +408,8 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
    * @param consecutiveActions Action played in between
    * @returns true if the action can be undone by the player that played it
    */
-  canUndo(action: Action<MaterialMove<Player, MaterialType, LocationType, RuleId>, Player>,
-          consecutiveActions: Action<MaterialMove<Player, MaterialType, LocationType, RuleId>, Player>[]): boolean {
+  canUndo(action: Action<MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player>,
+          consecutiveActions: Action<MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player>[]): boolean {
     for (let i = consecutiveActions.length - 1; i >= 0; i--) {
       if (this.consecutiveActionBlocksUndo(action, consecutiveActions[i])) {
         return false
@@ -418,8 +418,8 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
     return !this.actionBlocksUndo(action)
   }
 
-  private consecutiveActionBlocksUndo(action: Action<MaterialMove<Player, MaterialType, LocationType, RuleId>, Player>,
-                                      consecutiveAction: Action<MaterialMove<Player, MaterialType, LocationType, RuleId>, Player>): boolean {
+  private consecutiveActionBlocksUndo(action: Action<MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player>,
+                                      consecutiveAction: Action<MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player>): boolean {
     if (this.actionActivatesPlayer(consecutiveAction)) {
       return true
     }
@@ -431,7 +431,7 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
     return false
   }
 
-  private actionBlocksUndo(action: Action<MaterialMove<Player, MaterialType, LocationType, RuleId>, Player>): boolean {
+  private actionBlocksUndo(action: Action<MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player>): boolean {
     if (this.actionEndedSimultaneousPhase(action)) return true
     for (let i = action.consequences.length - 1; i >= 0; i--) {
       if (this.moveBlocksUndo(action.consequences[i], action.playerId)) {
@@ -445,7 +445,7 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
    * A player should never be able to undo an action that ended a simultaneous phase,
    * because going back into a simultaneous phase after a rule change is not allowed.
    */
-  private actionEndedSimultaneousPhase(action: Action<MaterialMove<Player, MaterialType, LocationType, RuleId>, Player>): boolean {
+  private actionEndedSimultaneousPhase(action: Action<MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player>): boolean {
     const { move, consequences } = action
     const hasEndTurn = (isEndPlayerTurn(move) && move.player === action.playerId)
       || consequences.some(c => isEndPlayerTurn(c) && c.player === action.playerId)
@@ -453,7 +453,7 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
     return consequences.some(c => c.kind === MoveKind.RulesMove && !isEndPlayerTurn(c))
   }
 
-  private actionActivatesPlayer(action: Action<MaterialMove<Player, MaterialType, LocationType, RuleId>, Player>): boolean {
+  private actionActivatesPlayer(action: Action<MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player>): boolean {
     for (let i = action.consequences.length - 1; i >= 0; i--) {
       if (this.moveActivatesPlayer(action.consequences[i])) {
         return true
@@ -471,7 +471,7 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
    * @param player The player that triggered the move
    * @returns true if the move blocks the undo
    */
-  protected moveBlocksUndo(move: MaterialMove<Player, MaterialType, LocationType, RuleId>, player?: Player): boolean {
+  protected moveBlocksUndo(move: MaterialMove<Player, MaterialType, LocationType, RuleId, View>, player?: Player): boolean {
     return this.moveActivatesPlayer(move, player) || isRoll(move)
   }
 
@@ -483,7 +483,7 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
   /**
    * Restore help display & local item moves
    */
-  restoreTransientState(previousState: MaterialGame<Player, MaterialType, LocationType, RuleId>) {
+  restoreTransientState(previousState: MaterialGame<Player, MaterialType, LocationType, RuleId, View>) {
     this.game.helpDisplay = previousState.helpDisplay
     this.game.transientItems = previousState.transientItems
     this.game.view = previousState.view
@@ -514,7 +514,7 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
    * @param move Material move to consider
    * @returns true if the move must wait for all other animations to complete
    */
-  isSequentialMove(move: MaterialMove<Player, MaterialType, LocationType, RuleId>): boolean {
+  isSequentialMove(move: MaterialMove<Player, MaterialType, LocationType, RuleId, View>): boolean {
     return move.kind === MoveKind.RulesMove && move.type !== RuleMoveType.EndPlayerTurn
   }
 
@@ -541,10 +541,10 @@ export abstract class MaterialRules<Player extends number = number, MaterialType
 /**
  * Signature interface of the constructor of a class that implements MaterialRules
  */
-export interface MaterialRulesCreator<P extends number = number, M extends number = number, L extends number = number, R extends number = number> {
-  new(state: MaterialGame<P, M, L, R>, client?: {
+export interface MaterialRulesCreator<P extends number = number, M extends number = number, L extends number = number, R extends number = number, V extends number = number> {
+  new(state: MaterialGame<P, M, L, R, V>, client?: {
     player?: P
-  }): MaterialRules<P, M, L, R>
+  }): MaterialRules<P, M, L, R, V>
 }
 
 function getItemMoveIndexes(move: ItemMove): number[] {

--- a/src/material/SecretMaterialRules.ts
+++ b/src/material/SecretMaterialRules.ts
@@ -9,9 +9,9 @@ import { MaterialMove, MaterialMoveRandomized } from './moves'
  * Using some {@link HidingSecretsStrategy} allows to enforce the security of a game with secret information easily.
  * If the game has only hidden information (all players have the same information), then you must implement {@link HiddenMaterialRules} instead.
  */
-export abstract class SecretMaterialRules<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number>
-  extends HiddenMaterialRules<Player, MaterialType, LocationType, RuleId>
-  implements SecretInformation<MaterialGame<Player, MaterialType, LocationType, RuleId>, MaterialMove<Player, MaterialType, LocationType, RuleId>, MaterialMove<Player, MaterialType, LocationType, RuleId>, Player> {
+export abstract class SecretMaterialRules<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number, View extends number = number>
+  extends HiddenMaterialRules<Player, MaterialType, LocationType, RuleId, View>
+  implements SecretInformation<MaterialGame<Player, MaterialType, LocationType, RuleId, View>, MaterialMove<Player, MaterialType, LocationType, RuleId, View>, MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player> {
 
   /**
    * Link {@link HiddenMaterialRules.hidingStrategies}, but with knowledge of whom the item should be hidden from.
@@ -22,14 +22,14 @@ export abstract class SecretMaterialRules<Player extends number = number, Materi
   /**
    * With the material approach, we can offer a default working implementation for {@link SecretInformation.getPlayerView}
    */
-  getPlayerView(player: Player): MaterialGame<Player, MaterialType, LocationType, RuleId> {
+  getPlayerView(player: Player): MaterialGame<Player, MaterialType, LocationType, RuleId, View> {
     return this.getView(player)
   }
 
   /**
    * With the material approach, we can offer a default working implementation for {@link SecretInformation.getPlayerMoveView}
    */
-  getPlayerMoveView(move: MaterialMoveRandomized<Player, MaterialType, LocationType, RuleId>, player: Player): MaterialMove<Player, MaterialType, LocationType, RuleId> {
+  getPlayerMoveView(move: MaterialMoveRandomized<Player, MaterialType, LocationType, RuleId, View>, player: Player): MaterialMove<Player, MaterialType, LocationType, RuleId, View> {
     return this.getMoveView(move, player)
   }
 }

--- a/src/material/moves/MaterialMove.ts
+++ b/src/material/moves/MaterialMove.ts
@@ -6,26 +6,26 @@ import { LocalMove } from './local'
 /**
  * Common type of all the kind of moves that can exists in a game implemented with {@link MaterialRules}
  */
-export type MaterialMove<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number> =
+export type MaterialMove<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number, View extends number = number> =
   ItemMove<Player, MaterialType, LocationType>
   | RuleMove<Player, RuleId>
   | CustomMove
-  | LocalMove<Player, MaterialType, LocationType>
+  | LocalMove<Player, MaterialType, LocationType, number, View>
 
 /**
  * A {@link MaterialMove} but after it is randomized (see {@link RandomMove})
  */
-export type MaterialMoveRandomized<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number> =
+export type MaterialMoveRandomized<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number, View extends number = number> =
   | ItemMoveRandomized<Player, MaterialType, LocationType>
   | RuleMove<Player, RuleId>
   | CustomMove
-  | LocalMove<Player, MaterialType, LocationType>
+  | LocalMove<Player, MaterialType, LocationType, number, View>
 
 /**
  * A {@link MaterialMove} but after it is transformed to be sent to players (see {@link HiddenMaterialRules}).
  */
-export type MaterialMoveView<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number> =
+export type MaterialMoveView<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number, View extends number = number> =
   | ItemMoveView<Player, MaterialType, LocationType>
   | RuleMove<Player, RuleId>
   | CustomMove
-  | LocalMove<Player, MaterialType, LocationType>
+  | LocalMove<Player, MaterialType, LocationType, number, View>

--- a/src/material/rules/MaterialRulesPart.ts
+++ b/src/material/rules/MaterialRulesPart.ts
@@ -10,8 +10,8 @@ import { RuleStep } from './RuleStep'
  * This is the base class to implement one part of the rules.
  * The constructor cannot be changed as the class is instantiated by {@link MaterialRules}.
  */
-export abstract class MaterialRulesPart<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number>
-  extends Rules<MaterialGame<Player, MaterialType, LocationType, RuleId>, MaterialMove<Player, MaterialType, LocationType, RuleId>, Player> {
+export abstract class MaterialRulesPart<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number, View extends number = number>
+  extends Rules<MaterialGame<Player, MaterialType, LocationType, RuleId, View>, MaterialMove<Player, MaterialType, LocationType, RuleId, View>, Player> {
 
   /**
    * Helper function to get a {@link Material} instance to work on some item type in the game.
@@ -28,7 +28,7 @@ export abstract class MaterialRulesPart<Player extends number = number, Material
    * @param _context Context of execution
    * @returns {MaterialMove[]} Any consequences that should automatically be played after the move
    */
-  beforeItemMove(_move: ItemMove<Player, MaterialType, LocationType>, _context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  beforeItemMove(_move: ItemMove<Player, MaterialType, LocationType>, _context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     return []
   }
 
@@ -38,7 +38,7 @@ export abstract class MaterialRulesPart<Player extends number = number, Material
    * @param _context Context of execution
    * @returns {MaterialMove[]} Any consequences that should automatically be played after the move
    */
-  afterItemMove(_move: ItemMove<Player, MaterialType, LocationType>, _context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  afterItemMove(_move: ItemMove<Player, MaterialType, LocationType>, _context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     return []
   }
 
@@ -49,7 +49,7 @@ export abstract class MaterialRulesPart<Player extends number = number, Material
    * @param _context Context of execution
    * @returns {MaterialMove[]} Any consequences that should automatically be played after the move
    */
-  onRuleStart(_move: RuleMove<Player, RuleId>, _previousRule?: RuleStep, _context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  onRuleStart(_move: RuleMove<Player, RuleId>, _previousRule?: RuleStep, _context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     return []
   }
 
@@ -62,7 +62,7 @@ export abstract class MaterialRulesPart<Player extends number = number, Material
    * @param _context Context of execution
    * @returns {MaterialMove[]} Any consequences that should automatically be played after the move
    */
-  onRuleEnd(_move: RuleMove<Player, RuleId>, _context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  onRuleEnd(_move: RuleMove<Player, RuleId>, _context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     return []
   }
 
@@ -72,7 +72,7 @@ export abstract class MaterialRulesPart<Player extends number = number, Material
    * @param _context Context of execution
    * @returns {MaterialMove[]} Any consequences that should automatically be played after the move
    */
-  onCustomMove(_move: CustomMove, _context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  onCustomMove(_move: CustomMove, _context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     return []
   }
 
@@ -135,7 +135,7 @@ export abstract class MaterialRulesPart<Player extends number = number, Material
    * @deprecated because of the lifecycle of this method, the game state must never be modified inside it. However, it is a very common mistake, so
    * this method should not be used in the material rules parts: use {@link play} method to return the automatic moves.
    */
-  getAutomaticMoves(): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  getAutomaticMoves(): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     return []
   }
 }
@@ -146,9 +146,10 @@ export abstract class MaterialRulesPart<Player extends number = number, Material
 export interface MaterialRulesPartCreator<Player extends number = number,
   MaterialType extends number = number,
   LocationType extends number = number,
-  RuleId extends number = number
+  RuleId extends number = number,
+  View extends number = number,
 > {
   new(
-    game: MaterialGame<Player, MaterialType, LocationType, RuleId>
-  ): MaterialRulesPart<Player, MaterialType, LocationType, RuleId>
+    game: MaterialGame<Player, MaterialType, LocationType, RuleId, View>
+  ): MaterialRulesPart<Player, MaterialType, LocationType, RuleId, View>
 }

--- a/src/material/rules/PlayerTurnRule.ts
+++ b/src/material/rules/PlayerTurnRule.ts
@@ -4,8 +4,8 @@ import { MaterialRulesPart } from './MaterialRulesPart'
 /**
  * Base class for any part of the rules where only one player has to do something.
  */
-export abstract class PlayerTurnRule<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number>
-  extends MaterialRulesPart<Player, MaterialType, LocationType, RuleId> {
+export abstract class PlayerTurnRule<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number, View extends number = number>
+  extends MaterialRulesPart<Player, MaterialType, LocationType, RuleId, View> {
 
   /**
    * Shortcut to get the awaited player (this.game.rule.player)
@@ -31,7 +31,7 @@ export abstract class PlayerTurnRule<Player extends number = number, MaterialTyp
   /**
    * See {@link Rules.getLegalMoves}
    */
-  getLegalMoves(player: Player): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  getLegalMoves(player: Player): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     if (player !== this.getActivePlayer()) return []
     return this.getPlayerMoves()
   }
@@ -40,7 +40,7 @@ export abstract class PlayerTurnRule<Player extends number = number, MaterialTyp
    * Implement this to expose all the legal moves of the active player.
    * @returns All the {@link MaterialMove} that current active player can play
    */
-  getPlayerMoves(): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  getPlayerMoves(): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     return []
   }
 }

--- a/src/material/rules/SimultaneousRule.ts
+++ b/src/material/rules/SimultaneousRule.ts
@@ -5,8 +5,8 @@ import { MaterialRulesPart } from './MaterialRulesPart'
 /**
  * Base class for any part of the rules where multiple players have to do something at the same time.
  */
-export abstract class SimultaneousRule<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number>
-  extends MaterialRulesPart<Player, MaterialType, LocationType, RuleId> {
+export abstract class SimultaneousRule<Player extends number = number, MaterialType extends number = number, LocationType extends number = number, RuleId extends number = number, View extends number = number>
+  extends MaterialRulesPart<Player, MaterialType, LocationType, RuleId, View> {
 
   endPlayerTurn = MaterialMoveBuilder.endPlayerTurn
 
@@ -27,7 +27,7 @@ export abstract class SimultaneousRule<Player extends number = number, MaterialT
   /**
    * See {@link Rules.getLegalMoves}
    */
-  getLegalMoves(player: Player): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  getLegalMoves(player: Player): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     return this.isTurnToPlay(player) ? this.getActivePlayerLegalMoves(player) : []
   }
 
@@ -36,7 +36,7 @@ export abstract class SimultaneousRule<Player extends number = number, MaterialT
    * @param player Player to consider
    * @return the legal moves of the player
    */
-  abstract getActivePlayerLegalMoves(player: Player): MaterialMove<Player, MaterialType, LocationType, RuleId>[]
+  abstract getActivePlayerLegalMoves(player: Player): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[]
 
   /**
    * This function is called immediately after a {@link EndPlayerTurn} has been played.
@@ -44,7 +44,7 @@ export abstract class SimultaneousRule<Player extends number = number, MaterialT
    * @param _context Context of execution
    * @returns {MaterialMove[]} Any consequences that should automatically be played after the move
    */
-  onPlayerTurnEnd(_move: EndPlayerTurn<Player>, _context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId>[] {
+  onPlayerTurnEnd(_move: EndPlayerTurn<Player>, _context?: PlayMoveContext): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[] {
     return []
   }
 
@@ -53,7 +53,7 @@ export abstract class SimultaneousRule<Player extends number = number, MaterialT
    * Usually, a new rule part should start.
    * @returns the consequences when the last awaited player have played
    */
-  abstract getMovesAfterPlayersDone(): MaterialMove<Player, MaterialType, LocationType, RuleId>[]
+  abstract getMovesAfterPlayersDone(): MaterialMove<Player, MaterialType, LocationType, RuleId, View>[]
 }
 
 /**
@@ -61,8 +61,8 @@ export abstract class SimultaneousRule<Player extends number = number, MaterialT
  * @param rule The rule
  * @returns true if the rule if a {@link SimultaneousRule}
  */
-export function isSimultaneousRule<P extends number = number, M extends number = number, L extends number = number, R extends number = number>(
-  rule?: MaterialRulesPart<P, M, L, R>
-): rule is SimultaneousRule<P, M, L, R> {
-  return rule !== undefined && typeof (rule as SimultaneousRule<P, M, L, R>).getMovesAfterPlayersDone === 'function'
+export function isSimultaneousRule<P extends number = number, M extends number = number, L extends number = number, R extends number = number, V extends number = number>(
+  rule?: MaterialRulesPart<P, M, L, R, V>
+): rule is SimultaneousRule<P, M, L, R, V> {
+  return rule !== undefined && typeof (rule as SimultaneousRule<P, M, L, R, V>).getMovesAfterPlayersDone === 'function'
 }


### PR DESCRIPTION
This PR aims at improving type safety for the `View` generic parameter introduced in `MaterialGame`. These improvements are necessary to improve `View` type safety in front.